### PR TITLE
correctly use placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ The module supports [environment variable substitution](https://caddyserver.com/
 ```
 {
     storage redis {
-        username       "{env.REDIS_USERNAME}"
-        password       "{env.REDIS_PASSWORD}"
-        encryption_key "{env.REDIS_ENCRYPTION_KEY}"
+        username       "{$REDIS_USERNAME}"
+        password       "{$REDIS_PASSWORD}"
+        encryption_key "{$REDIS_ENCRYPTION_KEY}"
         compression    true
     }
 }

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -92,14 +92,8 @@ func (rs *RedisStorage) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				}
 			case "port":
 				// Reset Port to override defaults
-				rs.Port = []string{}
-				for _, val := range configVal {
-					_, err := strconv.Atoi(val)
-					if err != nil {
-						return d.Errf("invalid port value: %s", val)
-					}
-					rs.Port = append(rs.Port, val)
-				}
+				rs.Port = configVal
+
 			case "db":
 				dbParse, err := strconv.Atoi(configVal[0])
 				if err != nil {
@@ -214,6 +208,10 @@ func (rs *RedisStorage) finalizeConfiguration(ctx context.Context) error {
 		}
 	}
 	for idx, v := range rs.Port {
+		_, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("invalid port value: %s", v)
+		}
 		rs.Port[idx] = repl.ReplaceAll(v, "")
 	}
 	rs.MasterName = repl.ReplaceAll(rs.MasterName, "")

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -207,13 +207,15 @@ func (rs *RedisStorage) finalizeConfiguration(ctx context.Context) error {
 	rs.Password = repl.ReplaceAll(rs.Password, DefaultRedisPassword)
 	rs.MasterName = repl.ReplaceAll(rs.MasterName, "")
 	rs.KeyPrefix = repl.ReplaceAll(rs.KeyPrefix, DefaultKeyPrefix)
-	rs.EncryptionKey = repl.ReplaceAll(rs.EncryptionKey, "")
-	// Encryption_key length must be at least 32 characters
-	if len(rs.EncryptionKey) < 32 {
-		return fmt.Errorf("invalid length for 'encryption_key', must contain at least 32 bytes: %s", rs.EncryptionKey)
-	}
-	if len(rs.EncryptionKey) > 32 {
-		rs.EncryptionKey = rs.EncryptionKey[:32]
+	if len(rs.EncryptionKey) > 0 {
+		rs.EncryptionKey = repl.ReplaceAll(rs.EncryptionKey, "")
+		// Encryption_key length must be at least 32 characters
+		if len(rs.EncryptionKey) < 32 {
+			return fmt.Errorf("invalid length for 'encryption_key', must contain at least 32 bytes: %s", rs.EncryptionKey)
+		}
+		if len(rs.EncryptionKey) > 32 {
+			rs.EncryptionKey = rs.EncryptionKey[:32]
+		}
 	}
 
 	rs.TlsServerCertsPEM = repl.ReplaceAll(rs.TlsServerCertsPEM, "")

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -186,7 +186,7 @@ func (rs *RedisStorage) finalizeConfiguration(ctx context.Context) error {
 		rs.Address[idx] = net.JoinHostPort(host, port)
 	}
 	for idx, v := range rs.Host {
-		v = repl.ReplaceAll(v, "")
+		v = repl.ReplaceAll(v, DefaultRedisHost)
 		addr := net.ParseIP(v)
 		_, err := net.LookupHost(v)
 		if addr == nil && err != nil {
@@ -195,7 +195,7 @@ func (rs *RedisStorage) finalizeConfiguration(ctx context.Context) error {
 		rs.Host[idx] = v
 	}
 	for idx, v := range rs.Port {
-		v = repl.ReplaceAll(v, "")
+		v = repl.ReplaceAll(v, DefaultRedisPort)
 		_, err := strconv.Atoi(v)
 		if err != nil {
 			return fmt.Errorf("invalid port value: %s", v)
@@ -203,8 +203,8 @@ func (rs *RedisStorage) finalizeConfiguration(ctx context.Context) error {
 		rs.Port[idx] = v
 	}
 	rs.MasterName = repl.ReplaceAll(rs.MasterName, "")
-	rs.Username = repl.ReplaceAll(rs.Username, DefaultRedisUsername)
-	rs.Password = repl.ReplaceAll(rs.Password, DefaultRedisPassword)
+	rs.Username = repl.ReplaceAll(rs.Username, "")
+	rs.Password = repl.ReplaceAll(rs.Password, "")
 	rs.MasterName = repl.ReplaceAll(rs.MasterName, "")
 	rs.KeyPrefix = repl.ReplaceAll(rs.KeyPrefix, DefaultKeyPrefix)
 	if len(rs.EncryptionKey) > 0 {

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -186,19 +186,21 @@ func (rs *RedisStorage) finalizeConfiguration(ctx context.Context) error {
 		rs.Address[idx] = net.JoinHostPort(host, port)
 	}
 	for idx, v := range rs.Host {
-		rs.Host[idx] = repl.ReplaceAll(v, "")
+		v = repl.ReplaceAll(v, "")
 		addr := net.ParseIP(v)
 		_, err := net.LookupHost(v)
 		if addr == nil && err != nil {
 			return fmt.Errorf("invalid host value: %s", v)
 		}
+		rs.Host[idx] = v
 	}
 	for idx, v := range rs.Port {
+		v = repl.ReplaceAll(v, "")
 		_, err := strconv.Atoi(v)
 		if err != nil {
 			return fmt.Errorf("invalid port value: %s", v)
 		}
-		rs.Port[idx] = repl.ReplaceAll(v, "")
+		rs.Port[idx] = v
 	}
 	rs.MasterName = repl.ReplaceAll(rs.MasterName, "")
 	rs.Username = repl.ReplaceAll(rs.Username, DefaultRedisUsername)

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -186,7 +186,7 @@ func (rs *RedisStorage) finalizeConfiguration(ctx context.Context) error {
 		rs.Address[idx] = net.JoinHostPort(host, port)
 	}
 	for idx, v := range rs.Host {
-		v = repl.ReplaceAll(v, DefaultRedisHost)
+		v = repl.ReplaceAll(v, defaultHost)
 		addr := net.ParseIP(v)
 		_, err := net.LookupHost(v)
 		if addr == nil && err != nil {
@@ -195,7 +195,7 @@ func (rs *RedisStorage) finalizeConfiguration(ctx context.Context) error {
 		rs.Host[idx] = v
 	}
 	for idx, v := range rs.Port {
-		v = repl.ReplaceAll(v, DefaultRedisPort)
+		v = repl.ReplaceAll(v, defaultPort)
 		_, err := strconv.Atoi(v)
 		if err != nil {
 			return fmt.Errorf("invalid port value: %s", v)
@@ -206,7 +206,7 @@ func (rs *RedisStorage) finalizeConfiguration(ctx context.Context) error {
 	rs.Username = repl.ReplaceAll(rs.Username, "")
 	rs.Password = repl.ReplaceAll(rs.Password, "")
 	rs.MasterName = repl.ReplaceAll(rs.MasterName, "")
-	rs.KeyPrefix = repl.ReplaceAll(rs.KeyPrefix, DefaultKeyPrefix)
+	rs.KeyPrefix = repl.ReplaceAll(rs.KeyPrefix, defaultKeyPrefix)
 	if len(rs.EncryptionKey) > 0 {
 		rs.EncryptionKey = repl.ReplaceAll(rs.EncryptionKey, "")
 		// Encryption_key length must be at least 32 characters

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -222,6 +222,13 @@ func (rs *RedisStorage) finalizeConfiguration(ctx context.Context) error {
 	rs.MasterName = repl.ReplaceAll(rs.MasterName, "")
 	rs.KeyPrefix = repl.ReplaceAll(rs.KeyPrefix, DefaultKeyPrefix)
 	rs.EncryptionKey = repl.ReplaceAll(rs.EncryptionKey, "")
+	// Encryption_key length must be at least 32 characters
+	if len(rs.EncryptionKey) < 32 {
+		return fmt.Errorf("invalid length for 'encryption_key', must contain at least 32 bytes: %s", rs.EncryptionKey)
+	}
+	if len(rs.EncryptionKey) > 32 {
+		rs.EncryptionKey = rs.EncryptionKey[:32]
+	}
 
 	rs.TlsServerCertsPEM = repl.ReplaceAll(rs.TlsServerCertsPEM, "")
 	rs.TlsServerCertsPath = repl.ReplaceAll(rs.TlsServerCertsPath, "")

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -87,11 +87,7 @@ func (rs *RedisStorage) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				// Reset Host to override defaults
 				rs.Host = []string{}
 				for _, val := range configVal {
-					addr := net.ParseIP(val)
-					_, err := net.LookupHost(val)
-					if addr == nil && err != nil {
-						return d.Errf("invalid host value: %s", val)
-					}
+
 					rs.Host = append(rs.Host, val)
 				}
 			case "port":
@@ -211,6 +207,11 @@ func (rs *RedisStorage) finalizeConfiguration(ctx context.Context) error {
 	}
 	for idx, v := range rs.Host {
 		rs.Host[idx] = repl.ReplaceAll(v, "")
+		addr := net.ParseIP(v)
+		_, err := net.LookupHost(v)
+		if addr == nil && err != nil {
+			return fmt.Errorf("invalid host value: %s", v)
+		}
 	}
 	for idx, v := range rs.Port {
 		rs.Port[idx] = repl.ReplaceAll(v, "")

--- a/defaults.go
+++ b/defaults.go
@@ -1,9 +1,7 @@
 package storageredis
 
 const (
-	DefaultRedisHost     = "127.0.0.1"
-	DefaultRedisPort     = "6379"
-	DefaultRedisUsername = ""
-	DefaultRedisPassword = ""
-	DefaultKeyPrefix     = "caddy"
+	DefaultRedisHost = "127.0.0.1"
+	DefaultRedisPort = "6379"
+	DefaultKeyPrefix = "caddy"
 )

--- a/defaults.go
+++ b/defaults.go
@@ -1,7 +1,0 @@
-package storageredis
-
-const (
-	DefaultRedisHost = "127.0.0.1"
-	DefaultRedisPort = "6379"
-	DefaultKeyPrefix = "caddy"
-)

--- a/defaults.go
+++ b/defaults.go
@@ -1,0 +1,9 @@
+package storageredis
+
+const (
+	DefaultRedisHost     = "127.0.0.1"
+	DefaultRedisPort     = "6379"
+	DefaultRedisUsername = ""
+	DefaultRedisPassword = ""
+	DefaultKeyPrefix     = "caddy"
+)


### PR DESCRIPTION
attempts to address #4 

it moves validation to Provision, and also uses the replacer at that time.

it also adds back some default variables from caddy-tlsredis.

note that caddytls-redis did this correctly - and so this should also help other people who are migrating. (the author has recommended using this package) 


existing people relying on this behavior should change their configs to {$ENV} syntax from {env.Env} syntax